### PR TITLE
Fix invalid hash value for Slack v3.3.3 64bit

### DIFF
--- a/slack.json
+++ b/slack.json
@@ -5,7 +5,7 @@
     "architecture": {
         "64bit": {
             "url": "https://downloads.slack-edge.com/releases_x64/slack-3.3.3-full.nupkg#/dl.7z",
-            "hash": "sha1:f7a70c72c788e355a6f7cb9f3bba68aa5de99628"
+            "hash": "sha1:fdc8b3b3921e807e4f6da6240ffa84ce822b47e0"
         },
         "32bit": {
             "url": "https://downloads.slack-edge.com/releases/slack-3.3.3-full.nupkg#/dl.7z",


### PR DESCRIPTION
File hash for Slack package v3.3.3 ([https://downloads.slack-edge.com/releases_x64/slack-3.3.3-full.nupkg](https://downloads.slack-edge.com/releases_x64/slack-3.3.3-full.nupkg)) was invalid.